### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   - push
-  - pull_request
+#   - pull_request
 
 
 jobs:


### PR DESCRIPTION
CI on PR is a bit redundant with CI on push. I suggest to only keep on push.
This goes in pair with my upgrade of main branch protection (which is increased).