### PR TITLE
Export TransactionType constant

### DIFF
--- a/example/simple.jl
+++ b/example/simple.jl
@@ -1,0 +1,8 @@
+using GraknClient
+
+client = GraknBlockingClient()
+session = Session(client, "phone_calls")
+txn = Transaction(session, TransactionType.READ, GraknOptions())
+close(txn)
+close(session)
+close(client)

--- a/src/GraknClient.jl
+++ b/src/GraknClient.jl
@@ -18,7 +18,7 @@ using gRPC, Sockets, UUIDs, Dates
 import Base: show, close, ==
 
 ###### abstract types ##################
-#                                      # 
+#                                      #
 ########################################
 
 abstract type AbstractTransaction end
@@ -29,8 +29,10 @@ abstract type AbstractConcept end
 abstract type AbstractThing <: AbstractConcept end
 
 ###### inlcudes ########################
-#                                      # 
+#                                      #
 ########################################
+
+include("exports.jl")
 
 include(joinpath(@__DIR__,"generated","grakn.jl"))
 include(joinpath(@__DIR__,"generated","grakn_pb.jl"))
@@ -47,6 +49,3 @@ include(joinpath(@__DIR__,"rpc","transaction.jl"))
 export GraknBlockingClient, GraknClientException, Session, Transaction
 
 end #module
-
-
-

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,0 +1,2 @@
+export GraknOptions
+export TransactionType

--- a/src/rpc/session.jl
+++ b/src/rpc/session.jl
@@ -6,7 +6,6 @@ using .grakn
 abstract type AbstractSession end
 abstract type Session <: AbstractSession end
 
-
 function _session_type_proto(session_type)
     return Int(session_type)
 end

--- a/src/rpc/transaction.jl
+++ b/src/rpc/transaction.jl
@@ -1,6 +1,9 @@
 # This file is a part of GraknClient.  License is MIT: https://github.com/Humans-of-Julia/GraknClient.jl/blob/main/LICENSE
 using UUIDs
 
+# Alias to the underlying constant so that we have a better name
+const TransactionType = grakn.protocol.Transaction_Type
+
 CLOSE_STREAM = "CLOSE_STREAM"
 
 mutable struct RequestIterator
@@ -15,10 +18,10 @@ mutable struct Transaction <: AbstractTransaction
         _concept_manager::T where {T<:Union{<:AbstractConceptManager, Nothing}}
         _query_manager::T where {T<:Union{<:AbstractQueryManager, Nothing}}
         _logic_manager::T where {T<:Union{<:AbstractLogicManager, Nothing}}
-        _response_queues::Dict{String,Any} 
+        _response_queues::Dict{String,Any}
         _grpc_stub::Union{GraknBlockingStub,Nothing}
         _request_iterator::Union{Channel{grakn.protocol.Transaction_Req},Nothing}
-        _response_iterator::Union{Channel{grakn.protocol.Transaction_Res},Nothing} 
+        _response_iterator::Union{Channel{grakn.protocol.Transaction_Res},Nothing}
         _transaction_was_closed::Bool
         _network_latency_millis::Number
 end
@@ -49,7 +52,7 @@ function Transaction(session::T, transaction_type::W, options::R) where {T<:Abst
         req.open_req = open_req
         res = @timed transaction(_grpc_stub, gRPCController(), req)
         _network_latency_millis = (res.time * 1000) - res.value.open_res.processing_time_millis
-        
+
         Transaction(options, _transaction_type, _concept_manager, _query_manager, _logic_manager, _response_queues, _grpc_stub, _request_iterator, _response_iterator, _transaction_was_closed, _network_latency_millis )
 end
 


### PR DESCRIPTION
See simple.jl script for an example.

Note that I have added a new `exports.jl` file. Some people like to put exports close to the implementation. However, I generally like to manage all exports in a single place. 