### PR TITLE
make the BDD test run stable and give an result

### DIFF
--- a/test/behaviour/connection/ConnectionStepsBase.jl
+++ b/test/behaviour/connection/ConnectionStepsBase.jl
@@ -14,6 +14,10 @@ end
 
 @given("connection does not have any database") do context
     all_dbs = g.get_all_databases(context[:client])
+    if !isempty(all_dbs)
+        delete_all_databases(context[:client])
+        all_dbs = g.get_all_databases(context[:client])
+    end
     @expect length(all_dbs) == 0
 end
 

--- a/test/runner.jl
+++ b/test/runner.jl
@@ -18,10 +18,13 @@ p = ParseOptions(allow_any_step_order = true)
 
 function run_tests(tag::String = "")
     runspec(rootpath; featurepath = featurepath, stepspath = stepspath,  parseoptions=p, execenvpath = configpath, tags=tag)
-    # runspec(rootpath; featurepath = featurepath, stepspath = stepspath,  parseoptions=p, execenvpath = configpath)
 end
 
 
-run_tests("not @ignore-typedb-core")
-# run_tests("@failure")
-# run_tests("@actual")
+result = run_tests("not @ignore-typedb-core")
+
+if !result
+    throw("TestSuite failed. Please proof the results")
+else
+    @info "Well done!"
+end


### PR DESCRIPTION
Now the run of the BDD test should be stable from the beginning and the test suite will throw an error at the end if something went wrong in it. For more results the user should check the result of the run.