### PR TITLE
Changed the precompiling directives

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -23,5 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.1.0](https://github.com/Humans-of-Julia/TypeDBClient.jl) - DATE
 
-We first introduce this `CHANGELOG` after release `v0.1.0`, so please refer to the GitHub release
-notes for this and earlier releases.
+## [v0.1.1](https://github.com/Humans-of-Julia/TypeDBClient.jl)
+
+- removed some precompiling statements for compatibility reasons of Julia 1.7.2

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TypeDBClient"
 uuid = "7ffdda62-db04-4838-9798-febd00f3125c"
 authors = ["Humans of Julia"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Behavior = "7a129280-419d-58e9-81ef-4f6801251892"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TypeDB Client for Julia (INCUBATING)
+# TypeDB Client for Julia
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://Humans-of-Julia.github.io/TypeDBClient.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://Humans-of-Julia.github.io/TypeDBClient.jl/dev)
@@ -16,8 +16,8 @@ Please review the user guide or if you'd like to help building this check the co
 
 Read up here: https://vaticle.com/
 
-> TypeDB is the knowledge graph engine to organise complex networks of data and making it queryable, by performing knowledge engineering. Rooted in Knowledge Representation and Automated Reasoning, TypeDB provides the 
-> knowledge foundation for cognitive and intelligent (e.g. AI) systems, by providing an intelligent language for modelling, transactions and analytics. Being a distributed database, TypeDB is designed to scale over a 
+> TypeDB is the knowledge graph engine to organise complex networks of data and making it queryable, by performing knowledge engineering. Rooted in Knowledge Representation and Automated Reasoning, TypeDB provides the
+> knowledge foundation for cognitive and intelligent (e.g. AI) systems, by providing an intelligent language for modelling, transactions and analytics. Being a distributed database, TypeDB is designed to scale over a
 > network of computers through partitioning and replication.
 
 ## Announcements

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -12,7 +12,8 @@ You can find install instructions in the [TypeDB Documentation](https://docs.vat
 
 | TypeDBClient.jl | TypeDB | TypeDB Cluster | Julia |
 |:--------------:|:-----------:|:------------:|:------------:|
-| 0.1.0 | 2.4      |     -     | >=1.6
+| 0.1.0 | 2.4         |     -     | >=1.6
+| 0.1.1 | 2.5, 2.6    |     -     | >=1.6
 
 Inside the Julia REPL, type ] to enter the Pkg REPL mode then run
 

--- a/src/precompile/precompile_ProtoBuf.jl
+++ b/src/precompile/precompile_ProtoBuf.jl
@@ -14,9 +14,9 @@ function _precompile_()
     @assert Base.precompile(Tuple{typeof(ProtoBuf.wiretype),Type{Vector{UInt8}}})   # time: 0.004197969
     @assert Base.precompile(Tuple{typeof(ProtoBuf.wiretype),Type{Float64}})   # time: 0.004151102
     @assert Base.precompile(Tuple{typeof(ProtoBuf.wiretype),Type{Dict{AbstractString, AbstractString}}})   # time: 0.004144187
-    @assert Base.precompile(Tuple{typeof(ProtoBuf.writeproto),IOBuffer,Vector{UInt8},ProtoMetaAttribs})   # time: 0.003951
+#    @assert Base.precompile(Tuple{typeof(ProtoBuf.writeproto),IOBuffer,Vector{UInt8},ProtoMetaAttribs})   # time: 0.003951
     @assert Base.precompile(Tuple{typeof(ProtoBuf.defaultval),Type{Int64}})   # time: 0.003861888
-    @assert Base.precompile(Tuple{typeof(ProtoBuf.writeproto),IOBuffer,Int32,ProtoMetaAttribs})   # time: 0.002705993
+#    @assert Base.precompile(Tuple{typeof(ProtoBuf.writeproto),IOBuffer,Int32,ProtoMetaAttribs})   # time: 0.002705993
     @assert Base.precompile(Tuple{typeof(ProtoBuf.defaultval),Type{Vector{UInt8}}})   # time: 0.001826776
 
     @info "Precompiling ProtoBuf done!"


### PR DESCRIPTION
Changing the precompiling directives was necessary for 1.7.2 compatibility reasons.
All tests are green for this.